### PR TITLE
Replace old Wiki link and replace freenode with libera chat

### DIFF
--- a/data/html/C/index.html
+++ b/data/html/C/index.html
@@ -118,7 +118,7 @@ Currently build servers, hosting and bandwidth is donated by EveryCity hosting i
 
 <ul>
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>

--- a/data/html/C/index.html
+++ b/data/html/C/index.html
@@ -120,7 +120,7 @@ Currently build servers, hosting and bandwidth is donated by EveryCity hosting i
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>IRC Channel: #openindiana on irc.freenode.net</li>
+  <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/br/index.html
+++ b/data/html/br/index.html
@@ -121,7 +121,7 @@ Atualmente os servidores de build, hospedagem e disponibilidade de banda são do
   <li>Site oficial: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Lista de e-mail/Discussão: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>Canal IRC: #openindiana on irc.freenode.net</li>
+  <li>Canal IRC: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/br/index.html
+++ b/data/html/br/index.html
@@ -119,7 +119,7 @@ Atualmente os servidores de build, hospedagem e disponibilidade de banda são do
 
 <ul>
   <li>Site oficial: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Lista de e-mail/Discussão: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>Canal IRC: #openindiana on irc.libera.chat</li>
 </ul>

--- a/data/html/de/index.html
+++ b/data/html/de/index.html
@@ -122,7 +122,7 @@ laden wir alle an der Zukunft von OpenIndiana Interessierten zur Beteiligung und
 
 <ul>
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Mailing Listen: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>IRC Channel: #openindiana im irc.libera.chat</li>
 </ul>

--- a/data/html/de/index.html
+++ b/data/html/de/index.html
@@ -124,7 +124,7 @@ laden wir alle an der Zukunft von OpenIndiana Interessierten zur Beteiligung und
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Mailing Listen: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>IRC Channel: #openindiana im irc.freenode.net</li>
+  <li>IRC Channel: #openindiana im irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/el/index.html
+++ b/data/html/el/index.html
@@ -134,7 +134,7 @@ Snapshot ελληνικά
 
 <ul>
   <li>Ιστοσελίδα: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Λίστες ηλ. ταχ.: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>Κανάλι IRC: #openindiana στο irc.libera.chat</li>
 </ul>

--- a/data/html/el/index.html
+++ b/data/html/el/index.html
@@ -136,7 +136,7 @@ Snapshot ελληνικά
   <li>Ιστοσελίδα: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Λίστες ηλ. ταχ.: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>Κανάλι IRC: #openindiana στο irc.freenode.net</li>
+  <li>Κανάλι IRC: #openindiana στο irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/en/index.html
+++ b/data/html/en/index.html
@@ -118,7 +118,7 @@ Currently build servers, hosting and bandwidth is donated by EveryCity hosting i
 
 <ul>
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>

--- a/data/html/en/index.html
+++ b/data/html/en/index.html
@@ -120,7 +120,7 @@ Currently build servers, hosting and bandwidth is donated by EveryCity hosting i
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>IRC Channel: #openindiana on irc.freenode.net</li>
+  <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/es/index.html
+++ b/data/html/es/index.html
@@ -118,7 +118,7 @@ Actualmente construir servidores, hosting y el ancho de banda es donado por Ever
 
 <ul>
   <li>Página web: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Listas de correo: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>Canal IRC: #openindiana on irc.libera.chat</li>
 </ul>

--- a/data/html/es/index.html
+++ b/data/html/es/index.html
@@ -120,7 +120,7 @@ Actualmente construir servidores, hosting y el ancho de banda es donado por Ever
   <li>Página web: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Listas de correo: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>Canal IRC: #openindiana on irc.freenode.net</li>
+  <li>Canal IRC: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/fr/index.html
+++ b/data/html/fr/index.html
@@ -120,7 +120,7 @@ L'infrastructure d'hébergement du projet est généreusement fournie par la soc
   <li>Site Web&#8239;: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki&#8239;: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Listes de diffusion&#8239;: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>Canal IRC&#8239;: #openindiana on irc.freenode.net</li>
+  <li>Canal IRC&#8239;: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/nl/index.html
+++ b/data/html/nl/index.html
@@ -120,7 +120,7 @@ Op dit moment worden de build servers, hosting en bandbreedte gedoneerd door Eve
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>IRC Channel: #openindiana on irc.freenode.net</li>
+  <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/nl/index.html
+++ b/data/html/nl/index.html
@@ -118,7 +118,7 @@ Op dit moment worden de build servers, hosting en bandbreedte gedoneerd door Eve
 
 <ul>
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>

--- a/data/html/pl/index.html
+++ b/data/html/pl/index.html
@@ -119,7 +119,7 @@ Obecnie koszt infrastruktury serwerowej, hostingu i sieci pokrywany jest przez E
 
 <ul>
   <li>Strona: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Lista mailingowa: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>Kanały IRC: #openindiana na irc.libera.chat</li>
 </ul>

--- a/data/html/pl/index.html
+++ b/data/html/pl/index.html
@@ -121,7 +121,7 @@ Obecnie koszt infrastruktury serwerowej, hostingu i sieci pokrywany jest przez E
   <li>Strona: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Lista mailingowa: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>Kanały IRC: #openindiana na irc.freenode.net</li>
+  <li>Kanały IRC: #openindiana na irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/ru/index.html
+++ b/data/html/ru/index.html
@@ -118,7 +118,7 @@ OpenIndiana Hipster создаётся силами сообщества и дл
 
 <ul>
   <li>Сайт: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Списки рассылки: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>IRC канал: #openindiana on irc.libera.chat</li>
 </ul>

--- a/data/html/ru/index.html
+++ b/data/html/ru/index.html
@@ -120,7 +120,7 @@ OpenIndiana Hipster создаётся силами сообщества и дл
   <li>Сайт: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Списки рассылки: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>IRC канал: #openindiana on irc.freenode.net</li>
+  <li>IRC канал: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/sl/index.html
+++ b/data/html/sl/index.html
@@ -119,7 +119,7 @@ Trenutno strežnike za izgradnjo sistema, gostovanje in pasovno širino donira E
 
 <ul>
   <li>Spletna stran: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
   <li>Poštni seznami: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
   <li>Kanal IRC: #openindiana on irc.libera.chat</li>
 </ul>

--- a/data/html/sl/index.html
+++ b/data/html/sl/index.html
@@ -121,7 +121,7 @@ Trenutno strežnike za izgradnjo sistema, gostovanje in pasovno širino donira E
   <li>Spletna stran: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Wiki: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
   <li>Poštni seznami: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>Kanal IRC: #openindiana on irc.freenode.net</li>
+  <li>Kanal IRC: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>


### PR DESCRIPTION
- Update to replace the link to the old Wiki with the current docs website. At the moment the Wiki is linked as a source of documentation and the current docs website is not mentioned.
- In line with [oi-docs #190](https://github.com/OpenIndiana/oi-docs/pull/190), update the reference to freenode with one to libera chat instead.