### PR TITLE
Fix Wiki links, broken mailman and release notes links

### DIFF
--- a/data/html/C/index.html
+++ b/data/html/C/index.html
@@ -87,13 +87,6 @@ Project Indiana was led by Ian Murdock, founder of the Debian Linux Distribution
 
 <br>
 
-<h2>Release Notes</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>About Us</h2>
 
 <p>The OpenIndiana Project is a community of volunteers and UNIX enthusiasts from around the world.

--- a/data/html/C/index.html
+++ b/data/html/C/index.html
@@ -119,7 +119,7 @@ Currently build servers, hosting and bandwidth is donated by EveryCity hosting i
 <ul>
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Mailing Lists: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>
 

--- a/data/html/br/index.html
+++ b/data/html/br/index.html
@@ -120,7 +120,7 @@ Atualmente os servidores de build, hospedagem e disponibilidade de banda são do
 <ul>
   <li>Site oficial: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Lista de e-mail/Discussão: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Lista de e-mail/Discussão: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>Canal IRC: #openindiana on irc.libera.chat</li>
 </ul>
 

--- a/data/html/br/index.html
+++ b/data/html/br/index.html
@@ -88,13 +88,6 @@ O Projeto Indiana foi liderado por Ian Murdock, o fundador da distribuição Lin
 
 <br>
 
-<h2>Notas da versão:</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>Sobre nós</h2>
 
 <p>O Projeto OpenIndiana é uma comunidade formada por voluntários e entusiastas de Unix ao redor do mundo.

--- a/data/html/de/index.html
+++ b/data/html/de/index.html
@@ -89,13 +89,6 @@ Das Projekt Indiana wurde geleitet von Ian Murdock, dem Gründer der Debian Linu
 
 <br>
 
-<h2>Release Notes</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>Über uns</h2>
 
 <p>Das OpenIndiana Projekt ist eine weltweit verteilte Gemeinschaft von Freiwilligen und begeisterten Anhängern von Unix.

--- a/data/html/de/index.html
+++ b/data/html/de/index.html
@@ -123,7 +123,7 @@ laden wir alle an der Zukunft von OpenIndiana Interessierten zur Beteiligung und
 <ul>
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Mailing Listen: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Mailing Listen: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>IRC Channel: #openindiana im irc.libera.chat</li>
 </ul>
 

--- a/data/html/el/index.html
+++ b/data/html/el/index.html
@@ -135,7 +135,7 @@ Snapshot ελληνικά
 <ul>
   <li>Ιστοσελίδα: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Λίστες ηλ. ταχ.: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Λίστες ηλ. ταχ.: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>Κανάλι IRC: #openindiana στο irc.libera.chat</li>
 </ul>
 

--- a/data/html/el/index.html
+++ b/data/html/el/index.html
@@ -96,13 +96,6 @@ Sun Solaris και αναπτύχθηκε από την κοινότητα. Το
 
 <br>
 
-<h2>Ανακοινώσεις εκδόσεων</h2>
-Snapshot ελληνικά
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>Πληροφορίες για εμάς</h2>
 
 <p>Το πρότζεκτ του OpenIndiana αποτελείται από μία κοινότητα εθελοντών και λάτρεις

--- a/data/html/en/index.html
+++ b/data/html/en/index.html
@@ -87,13 +87,6 @@ Project Indiana was led by Ian Murdock, founder of the Debian Linux Distribution
 
 <br>
 
-<h2>Release Notes</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>About Us</h2>
 
 <p>The OpenIndiana Project is a community of volunteers and UNIX enthusiasts from around the world.

--- a/data/html/en/index.html
+++ b/data/html/en/index.html
@@ -119,7 +119,7 @@ Currently build servers, hosting and bandwidth is donated by EveryCity hosting i
 <ul>
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Mailing Lists: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>
 

--- a/data/html/es/index.html
+++ b/data/html/es/index.html
@@ -119,7 +119,7 @@ Actualmente construir servidores, hosting y el ancho de banda es donado por Ever
 <ul>
   <li>Página web: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Listas de correo: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Listas de correo: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>Canal IRC: #openindiana on irc.libera.chat</li>
 </ul>
 

--- a/data/html/es/index.html
+++ b/data/html/es/index.html
@@ -87,13 +87,6 @@ Proyecto Indiana fue dirigido por Ian Murdock, fundador de la distribución Debi
 
 <br>
 
-<h2>Notas de la versión</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>Sobre nosotros</h2>
 
 <p>El Proyecto OpenIndiana es una comunidad de voluntarios y UNIX los entusiastas de todo el mundo.

--- a/data/html/fr/index.html
+++ b/data/html/fr/index.html
@@ -119,7 +119,7 @@ L'infrastructure d'hébergement du projet est généreusement fournie par la soc
 <ul>
   <li>Site Web: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Listes de diffusion: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Listes de diffusion: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>Canal IRC: #openindiana on irc.libera.chat</li>
 </ul>
 

--- a/data/html/fr/index.html
+++ b/data/html/fr/index.html
@@ -87,13 +87,6 @@ Le Projet Indiana était mené par Ian Murdock, créateur de la distribution Deb
 
 <br>
 
-<h2>Notes de version</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>Qui sommes-nous&#8239;?</h2>
 
 <p>Le Projet OpenIndiana est constitué d'une communauté de volontaires, passionnés d'UNIX, provenant du monde entier.

--- a/data/html/fr/index.html
+++ b/data/html/fr/index.html
@@ -117,10 +117,10 @@ L'infrastructure d'hébergement du projet est généreusement fournie par la soc
 <h2>Liens</h2>
 
 <ul>
-  <li>Site Web&#8239;: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
-  <li>Wiki&#8239;: <a href="https://wiki.openindiana.org">https://wiki.openindiana.org</a></li><br>
-  <li>Listes de diffusion&#8239;: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
-  <li>Canal IRC&#8239;: #openindiana on irc.libera.chat</li>
+  <li>Site Web: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
+  <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
+  <li>Listes de diffusion: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Canal IRC: #openindiana on irc.libera.chat</li>
 </ul>
 
 <br>

--- a/data/html/nl/index.html
+++ b/data/html/nl/index.html
@@ -87,13 +87,6 @@ Project Indiana was led by Ian Murdock, founder of the Debian Linux Distribution
 
 <br>
 
-<h2>Release Notes</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>Over ons</h2>
 
 <p>De OpenIndiana Project is een community van vrijwilligers en UNIX enthousiastelingen vanuit de gehele wereld.

--- a/data/html/nl/index.html
+++ b/data/html/nl/index.html
@@ -119,7 +119,7 @@ Op dit moment worden de build servers, hosting en bandbreedte gedoneerd door Eve
 <ul>
   <li>Website: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Mailing Lists: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Mailing Lists: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>IRC Channel: #openindiana on irc.libera.chat</li>
 </ul>
 

--- a/data/html/pl/index.html
+++ b/data/html/pl/index.html
@@ -88,13 +88,6 @@ Projekt Indiana był prowadzony przez Ian Murdock, założyciela dystrybucji Deb
 
 <br>
 
-<h2>Release Notes</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>O nas</h2>
 
 <p>Projekt OpenIndiana jest społecznością wolontariuszy i entuzjastów UNIXa z całego świata.

--- a/data/html/pl/index.html
+++ b/data/html/pl/index.html
@@ -120,7 +120,7 @@ Obecnie koszt infrastruktury serwerowej, hostingu i sieci pokrywany jest przez E
 <ul>
   <li>Strona: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Lista mailingowa: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Lista mailingowa: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>Kanały IRC: #openindiana na irc.libera.chat</li>
 </ul>
 

--- a/data/html/ru/index.html
+++ b/data/html/ru/index.html
@@ -119,7 +119,7 @@ OpenIndiana Hipster создаётся силами сообщества и дл
 <ul>
   <li>Сайт: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Списки рассылки: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Списки рассылки: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>IRC канал: #openindiana on irc.libera.chat</li>
 </ul>
 

--- a/data/html/ru/index.html
+++ b/data/html/ru/index.html
@@ -87,13 +87,6 @@ OpenIndiana Hipster создаётся силами сообщества и дл
 
 <br>
 
-<h2>Примечания к выпуску:</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>О нас</h2>
 
 <p>Проект OpenIndiana представляет собой сообщество добровольцев и людей, увлеченных Unix-системами, находящихся в разных частях земного шара.

--- a/data/html/sl/index.html
+++ b/data/html/sl/index.html
@@ -88,13 +88,6 @@ Projekt Indiana je vodil Ian Murdock, ustanovitelj Distribucije Linux Debian.</p
 
 <br>
 
-<h2>Obvestila ob izdaji</h2>
-
-<a href="https://wiki.openindiana.org/oi/Release+Notes">https://wiki.openindiana.org/oi/Release+Notes</a>
-
-<br>
-<br>
-
 <h2>O nas</h2>
 
 <p>Projekt OpenIndiana je skupnost prostovoljcev in UNIX entuziastov z vsega sveta.

--- a/data/html/sl/index.html
+++ b/data/html/sl/index.html
@@ -120,7 +120,7 @@ Trenutno strežnike za izgradnjo sistema, gostovanje in pasovno širino donira E
 <ul>
   <li>Spletna stran: <a href="https://openindiana.org">https://openindiana.org</a></li><br>
   <li>Docs: <a href="https://docs.openindiana.org">https://docs.openindiana.org/</a></li><br>
-  <li>Poštni seznami: <a href="http://openindiana.org/mailman">http://openindiana.org/mailman</a></li><br>
+  <li>Poštni seznami: <a href="https://openindiana.org/mailman/listinfo/">https://openindiana.org/mailman/listinfo/</a></li><br>
   <li>Kanal IRC: #openindiana on irc.libera.chat</li>
 </ul>
 


### PR DESCRIPTION
There was a link to the Wiki on the French landing page which was missed before, now points to docs. Mailman link was giving 403, fixed in all languages. The release notes link was broken, this is now on the homepage which is already linked, thus removed for all languages.